### PR TITLE
accept question marks from root

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,38 +4,39 @@ var types = parse.types;
 module.exports = function (re, opts) {
     if (!opts) opts = {};
     var replimit = opts.limit === undefined ? 25 : opts.limit;
-    
+
     if (isRegExp(re)) re = re.source;
     else if (typeof re !== 'string') re = String(re);
-    
+
     try { re = parse(re) }
     catch (err) { return false }
-    
+
     var reps = 0;
-    return (function walk (node, starHeight) {
+    return (function walk (node, height, starHeight) {
         if (node.type === types.REPETITION) {
-            starHeight ++;
+            if (height > 1 || node.max !== 1)
+                starHeight ++;
             reps ++;
             if (starHeight > 1) return false;
             if (reps > replimit) return false;
         }
-        
+
         if (node.options) {
             for (var i = 0, len = node.options.length; i < len; i++) {
-                var ok = walk({ stack: node.options[i] }, starHeight);
+                var ok = walk({ stack: node.options[i] }, height+1, starHeight);
                 if (!ok) return false;
             }
         }
         var stack = node.stack || (node.value && node.value.stack);
         if (!stack) return true;
-        
+
         for (var i = 0; i < stack.length; i++) {
-            var ok = walk(stack[i], starHeight);
+            var ok = walk(stack[i], height+1, starHeight);
             if (!ok) return false;
         }
-        
+
         return true;
-    })(re, 0);
+    })(re, 0, 0);
 };
 
 function isRegExp (x) {


### PR DESCRIPTION
This small change allows the `?` operator at just the root level. For example, `^/foo(?:/(\d{16}))?` is now considered safe, however, `(?:foo(?:/foo)?)?` is not.

**But** it's important to note that right now, `?` is already available at any level. Consider the following: `(?:|foo(?:|/foo))` Which direction would you rather go, allow `?` everywhere or catch and ban the workaround? Or maybe the `|` operator is simply dangerous?